### PR TITLE
#17. Support single quotes for v-* and :* directives

### DIFF
--- a/babelvueextractor/lexer.py
+++ b/babelvueextractor/lexer.py
@@ -37,7 +37,7 @@ COMMENT_END = '-->'
 V_DIRECTIVE_PREFIX = 'v-'
 COLON_DIRECTIVE_PREFIX = '\x3a'  # 0x3a = ":"
 
-tag_re = re.compile('(%s.*?%s|%s.*?%s|%s.*?%s|%s.*?%s|%s.*?%s|(?:%s|%s).+?=".*?")' % (
+tag_re = re.compile('(%s.*?%s|%s.*?%s|%s.*?%s|%s.*?%s|%s.*?%s|(?:%s|%s).+?=(?:".*?"|\'.*?\'))' % (
     re.escape(CONST_START), re.escape(CONST_END),
     re.escape(RAW_HTML_TAG_START), re.escape(RAW_HTML_TAG_END),
     re.escape(VARIABLE_TAG_START), re.escape(VARIABLE_TAG_END),
@@ -131,10 +131,10 @@ class Lexer(object):
                 _end = len(VARIABLE_TAG_END)
                 token_type = TOKEN_VAR
 
-            elif token_string.endswith('"'):
+            elif token_string.endswith(('"', "'")):
                 token_type = TOKEN_DIRECTIVE
                 # eg. v-text="attr" => ['v-text=', 'attr', '']
-                content = token_string.split('"')[1]
+                content = token_string.split(token_string[-1])[1]
 
             if _start is not None:
                 content = token_string[_start:-_end].strip()

--- a/babelvueextractor/tests/test_lexer.py
+++ b/babelvueextractor/tests/test_lexer.py
@@ -1,6 +1,6 @@
 import unittest
 from babelvueextractor.lexer import Lexer, Token, TOKEN_TEXT, TOKEN_VAR, TOKEN_COMMENT, TOKEN_RAW_HTML, TOKEN_CONST, \
-    TOKEN_DOUBLE_WAY_BINDING
+    TOKEN_DOUBLE_WAY_BINDING, TOKEN_DIRECTIVE
 
 
 class TestLexer(unittest.TestCase):
@@ -50,6 +50,34 @@ class TestLexer(unittest.TestCase):
         self.assertTokensEqual(
             Lexer(content).tokenize(), [
                 Token(TOKEN_DOUBLE_WAY_BINDING, "foo")
+            ])
+
+    def test_v_attr(self):
+        content = "<div v-html='foo'>"
+        self.assertTokensEqual(
+            Lexer(content).tokenize(), [
+                Token(token_type=0, contents="<div "),
+                Token(TOKEN_DIRECTIVE, "foo")
+            ])
+        content = '<div v-html="bar">'
+        self.assertTokensEqual(
+            Lexer(content).tokenize(), [
+                Token(token_type=0, contents="<div "),
+                Token(TOKEN_DIRECTIVE, "bar")
+            ])
+
+    def test_colon_attr(self):
+        content = "<div :html='foo'>"
+        self.assertTokensEqual(
+            Lexer(content).tokenize(), [
+                Token(token_type=0, contents="<div "),
+                Token(TOKEN_DIRECTIVE, "foo")
+            ])
+        content = '<div :html="bar">'
+        self.assertTokensEqual(
+            Lexer(content).tokenize(), [
+                Token(token_type=0, contents="<div "),
+                Token(TOKEN_DIRECTIVE, "bar")
             ])
 
     def test_combine(self):


### PR DESCRIPTION
Fix issue #17. 

Add support for single quotes in v-* and :* directives, and tests